### PR TITLE
Fixing bug of successful unpadding when last byte is zero

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/pkcs7.iml" filepath="$PROJECT_DIR$/.idea/pkcs7.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/pkcs7.iml
+++ b/.idea/pkcs7.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -56,6 +56,12 @@ func Unpad(src []byte) ([]byte, error) {
 	// Get the last byte so we know how many bytes to take off the end.
 	padLen := int(src[length-1])
 
+	// If the last byte is 0x00, we have invalid padding. We try to fuzz a bit
+	// the error message, sending the same one as when the padding is incorrect.
+	if padLen == 0x00 {
+		return nil, errors.New("pkcs7: invalid padding (last byte does not match padding)")
+	}
+
 	// If the last byte is more than the total length, this is invalid.
 	if padLen > length {
 		return nil, errors.New("pkcs7: invalid padding (last byte is larger than total length)")

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -2,13 +2,15 @@ package pkcs7
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
 type testVector struct {
-	blockSize int
-	input     []byte
-	output    []byte
+	blockSize   int
+	input       []byte
+	output      []byte
+	errorString string
 }
 
 var padTests = []testVector{
@@ -23,6 +25,7 @@ var padTests = []testVector{
 			0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
 			0xDE, 0xAD, 0xBE, 0xEF, 0x04, 0x04, 0x04, 0x04,
 		},
+		"",
 	},
 
 	// Pads empty buffers.
@@ -33,6 +36,7 @@ var padTests = []testVector{
 			0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10,
 			0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10,
 		},
+		"",
 	},
 
 	// Pads buffers larger than the block size.
@@ -49,29 +53,69 @@ var padTests = []testVector{
 			0xDE, 0xAD, 0xBE, 0xEF, 0x0C, 0x0C, 0x0C, 0x0C,
 			0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C,
 		},
+		"",
+	},
+	// Error when block size is more than 255
+	{
+		256,
+		[]byte{0x01, 0x02, 0x03, 0x04},
+		nil,
+		"pkcs7: block size must be between 1 and 255 inclusive",
+	},
+	// (Pad only) Error when block size is zero
+	{
+		0,
+		[]byte{0x01, 0x02, 0x03, 0x04},
+		nil,
+		"pkcs7: block size must be between 1 and 255 inclusive",
+	},
+	// (Unpad only) Error when padded block  has a final zero bit
+	{
+		4,
+		nil,
+		[]byte{0x01, 0x02, 0x03, 0x00},
+		"pkcs7: invalid padding (last byte does not match padding)",
 	},
 }
 
 func TestPad(t *testing.T) {
 	for i, v := range padTests {
-		o, err := Pad(v.input, v.blockSize)
-		if err != nil {
-			t.Errorf("Padding caused error: %v", err)
-		}
-		if !bytes.Equal(o, v.output) {
-			t.Errorf("Pad %d: expected %x, got %x", i, v.output, o)
+		if v.input != nil {
+			o, err := Pad(v.input, v.blockSize)
+			if err != nil {
+				if v.errorString == "" {
+					t.Errorf("Padding caused error: %v", err)
+				} else if !strings.Contains(err.Error(), v.errorString) {
+					t.Errorf("Unexpected error: we expected %s but we received %v", v.errorString, err)
+					return
+				}
+			}
+			if v.output != nil {
+				if !bytes.Equal(o, v.output) {
+					t.Errorf("Pad %d: expected %x, got %x", i, v.output, o)
+				}
+			}
 		}
 	}
 }
 
 func TestUnpad(t *testing.T) {
 	for i, v := range padTests {
-		o, err := Unpad(v.output)
-		if err != nil {
-			t.Errorf("Valid padding caused error: %v", err)
-		}
-		if !bytes.Equal(o, v.input) {
-			t.Errorf("Unpad %d: expected %x, got %x", i, v.output, o)
+		if v.output != nil {
+			o, err := Unpad(v.output)
+			if err != nil {
+				if v.errorString == "" {
+					t.Errorf("Padding caused error: %v", err)
+				} else if !strings.Contains(err.Error(), v.errorString) {
+					t.Errorf("Unexpected error: we expected %s but we received %v", v.errorString, err)
+					return
+				}
+			}
+			if v.input != nil {
+				if !bytes.Equal(o, v.input) {
+					t.Errorf("Unpad %d: expected %x, got %x", i, v.output, o)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
When last byte of a message is zero and we want to unpad it, the library should throw an error (0x00 is not a valid padding byte). 

I copied the error for invalid padding (padding bytes different to the last one) instead of creating a new error, because I think the new error is an specific case of the other one.
